### PR TITLE
create fetch contents api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apk update && \
         nodejs \
         tzdata \
         shared-mime-info \
+        less \
         yarn && \
     apk add --virtual build-packs --no-cache \
         build-base \

--- a/Gemfile
+++ b/Gemfile
@@ -36,12 +36,16 @@ gem "bootsnap", require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem "rack-cors"
 
-gem "annotate"
-
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
+  gem "annotate"
   gem "debug", platforms: %i[mri mingw x64_mingw]
   gem "factory_bot_rails"
+  gem "pry-byebug"
+end
+
+group :test do
+  gem "webmock"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,8 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
     annotate (3.2.0)
       activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
@@ -73,7 +75,11 @@ GEM
     bootsnap (1.11.1)
       msgpack (~> 1.2)
     builder (3.2.4)
+    byebug (11.1.3)
+    coderay (1.1.3)
     concurrent-ruby (1.1.9)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     debug (1.4.0)
       irb (>= 1.3.6)
@@ -87,6 +93,7 @@ GEM
       railties (>= 5.0.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    hashdiff (1.0.1)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     io-console (0.5.11)
@@ -131,6 +138,13 @@ GEM
     parser (3.1.1.0)
       ast (~> 2.4.1)
     pg (1.3.4)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
+    public_suffix (4.0.7)
     puma (5.6.2)
       nio4r (~> 2.0)
     racc (1.6.0)
@@ -191,6 +205,10 @@ GEM
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
+    webmock (3.14.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -207,11 +225,13 @@ DEPENDENCIES
   debug
   factory_bot_rails
   pg (~> 1.1)
+  pry-byebug
   puma (~> 5.0)
   rails (~> 7.0.2, >= 7.0.2.3)
   rubocop
   rubocop-rails
   tzinfo-data
+  webmock
 
 RUBY VERSION
    ruby 3.1.1p18

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,0 +1,28 @@
+class BooksController < ApplicationController
+  def index
+    books = Book.all.map do |book|
+      {
+        id: book.id,
+        name: book.name,
+      }
+    end
+
+    render status: :ok, json: {
+      books:,
+    }
+  end
+
+  def show
+    book = Book.find_by(id: params[:id])
+    sections = book.sections.map do |section|
+      {
+        name: section.name,
+      }
+    end
+
+    render status: :ok, json: {
+      book: book.id,
+      sections:,
+    }
+  end
+end

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -1,0 +1,17 @@
+class SectionsController < ApplicationController
+  def show
+    section = Section.find_by(id: params[:id])
+    contents = section.contents.map do |content|
+      {
+        id: content.id,
+        question: content.question,
+        answer: content.answer,
+      }
+    end
+
+    render status: :ok, json: {
+      section: section.id,
+      contents:,
+    }
+  end
+end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -8,5 +8,5 @@
 #  updated_at :datetime         not null
 #
 class Book < ApplicationRecord
-  has_many :sections
+  has_many :sections, dependent: :restrict_with_exception
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -18,5 +18,5 @@
 #
 class Section < ApplicationRecord
   belongs_to :book
-  has_many :contents
+  has_many :contents, dependent: :restrict_with_exception
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,4 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Defines the root path route ("/")
-  # root "articles#index"
+  resources :books, only: [:index, :show]
   resources :sections, only: :show
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "articles#index"
+  resources :sections, only: :show
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
   web:
     build: .
     command: ash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    stdin_open: true
+    tty: true
     volumes:
       - .:/myapp
     ports:

--- a/test/controllers/books_controller_test.rb
+++ b/test/controllers/books_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class BooksControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/books_controller_test.rb
+++ b/test/controllers/books_controller_test.rb
@@ -1,7 +1,33 @@
 require "test_helper"
 
 class BooksControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  test "should success if request valid section id" do
+    book = create(:book, :with_section)
+
+    get book_path(book.id), headers: @stubbed_header, xhr: true
+    assert_response :success
+  end
+
+  test "#show should success response having book" do
+    book = create(:book, :with_section)
+
+    get book_path(book.id), headers: @stubbed_header, xhr: true
+    assert_response :success
+
+    response_contents = JSON.parse(response.body).deep_symbolize_keys
+
+    assert_equal book.id, response_contents[:book]
+  end
+
+  test "#show should success response having sections" do
+    book = create(:book)
+    section = create(:section, id: rand(1..10), book:)
+
+    get book_path(book.id), headers: @stubbed_header, xhr: true
+    assert_response :success
+
+    response_contents = JSON.parse(response.body).deep_symbolize_keys
+
+    assert_equal section.name, response_contents[:sections].first[:name]
+  end
 end

--- a/test/controllers/sections_controller_test.rb
+++ b/test/controllers/sections_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SectionsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/sections_controller_test.rb
+++ b/test/controllers/sections_controller_test.rb
@@ -1,7 +1,34 @@
 require "test_helper"
 
 class SectionsControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  test "should success if request valid content id" do
+    section = create(:section, :with_content)
+
+    get section_path(section.id), headers: @stubbed_header, xhr: true
+    assert_response :success
+  end
+
+  test "#show should success response having section" do
+    section = create(:section, :with_content)
+
+    get section_path(section.id), headers: @stubbed_header, xhr: true
+    assert_response :success
+
+    response_contents = JSON.parse(response.body).deep_symbolize_keys
+
+    assert_equal section.id, response_contents[:section]
+  end
+
+  test "#show should success response having contents" do
+    section = create(:section)
+    content = create(:content, id: rand(1..10), section:)
+
+    get section_path(section.id), headers: @stubbed_header, xhr: true
+    assert_response :success
+
+    response_contents = JSON.parse(response.body).deep_symbolize_keys
+
+    assert_equal content.question, response_contents[:contents].first[:question]
+    assert_equal content.answer, response_contents[:contents].first[:answer]
+  end
 end

--- a/test/factories/books.rb
+++ b/test/factories/books.rb
@@ -10,5 +10,10 @@
 FactoryBot.define do
   factory :book do
     sequence(:name) { |n| "book_#{n}" }
+    trait :with_section do
+      after(:create) do |book|
+        create(:section, book:)
+      end
+    end
   end
 end

--- a/test/factories/books.rb
+++ b/test/factories/books.rb
@@ -9,6 +9,6 @@
 #
 FactoryBot.define do
   factory :book do
-    
+    sequence(:name) { |n| "book_#{n}" }
   end
 end

--- a/test/factories/contents.rb
+++ b/test/factories/contents.rb
@@ -23,5 +23,7 @@ FactoryBot.define do
   factory :content do
     sequence(:question) { |n| "question_#{n}" }
     sequence(:answer) { |n| "answer_#{n}" }
+
+    association :section
   end
 end

--- a/test/factories/contents.rb
+++ b/test/factories/contents.rb
@@ -21,6 +21,7 @@
 #
 FactoryBot.define do
   factory :content do
-    
+    sequence(:question) { |n| "question_#{n}" }
+    sequence(:answer) { |n| "answer_#{n}" }
   end
 end

--- a/test/factories/sections.rb
+++ b/test/factories/sections.rb
@@ -19,5 +19,12 @@
 FactoryBot.define do
   factory :section do
     sequence(:name) { |n| "section_#{n}" }
+    trait :with_content do
+      after(:create) do |section|
+        create(:content, section:)
+      end
+    end
+
+    association :book
   end
 end

--- a/test/factories/sections.rb
+++ b/test/factories/sections.rb
@@ -18,6 +18,6 @@
 #
 FactoryBot.define do
   factory :section do
-    
+    sequence(:name) { |n| "section_#{n}" }
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,14 @@
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
+require "webmock/minitest"
+
+class ActionDispatch::IntegrationTest
+  # TODO: rubocop force name to snake_case, but setup is correct
+  def set_up
+    @stubbed_header = { Authorization: SecureRandom.hex(10) }
+  end
+end
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers


### PR DESCRIPTION
## What does this MR do?
- The MR create fetch api for book, section, and content
- Install pry-byebug for debug

## How to set up and validate locally
- curl http://localhost:3000/books/1
```
{"book":1,"sections":[{"name":"1"},{"name":"2"},{"name":"3"},{"name":"4"},{"name":"5"}]}
```

- curl http://localhost:3000/sections/1
```
{"section":1,"contents":[{"id":1,"question":"個人の意志は尊重しなければいけない","answer":"We must respect the will of the individual"},{"id":2,"question":"気楽にいけよ。大丈夫、すべてうまくいくさ","answer":"Take it easy. I can assure you that everything will turn out fine"}}]}
```

## Note  
- Support Swagger later